### PR TITLE
Add dispose_ownership_transfer_at_constructor

### DIFF
--- a/Editorconfig/.editorconfig
+++ b/Editorconfig/.editorconfig
@@ -3450,6 +3450,7 @@ dotnet_diagnostic.CA1869.severity = suggestion
 ## Dispose objects before losing scope (CA2000)
 ## If a disposable object is not explicitly disposed before all references to it are out of scope, the object will be disposed at some indeterminate time when the garbage collector runs the finalizer of the object. Because an exceptional event might occur that will prevent the finalizer of the object from running, the object should be explicitly disposed instead.
 dotnet_diagnostic.CA2000.severity = warning
+dotnet_code_quality.dispose_ownership_transfer_at_constructor = true
 
 ## Do not lock on objects with weak identity (CA2002)
 ## An object is said to have a weak identity when it can be directly accessed across application domain boundaries. A thread that tries to acquire a lock on an object that has a weak identity can be blocked by a second thread in a different application domain that has a lock on the same object.

--- a/Editorconfig/Directory.Build.props
+++ b/Editorconfig/Directory.Build.props
@@ -6,7 +6,7 @@
     <Company>Kysect</Company>
     <RepositoryUrl>https://github.com/kysect/CodeRules</RepositoryUrl>
     <PackageProjectUrl>https://github.com/kysect/CodeRules</PackageProjectUrl>
-    <Version>1.1.6</Version>
+    <Version>1.1.7</Version>
     <PackageReadmeFile>Readme.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
 


### PR DESCRIPTION
Motivation: reduce count of false positive.

More details: https://publish.obsidian.md/how-to-kats/Knowledge+base/Developing/Code/Languages/Dotnet/Roslyn/Analyzers/Roslyn+analyzers+-+Disposing