### PR TITLE
Skip copy task in case when SolutionDir is not specified

### DIFF
--- a/Editorconfig/Directory.Build.props
+++ b/Editorconfig/Directory.Build.props
@@ -6,7 +6,7 @@
     <Company>Kysect</Company>
     <RepositoryUrl>https://github.com/kysect/CodeRules</RepositoryUrl>
     <PackageProjectUrl>https://github.com/kysect/CodeRules</PackageProjectUrl>
-    <Version>1.1.7</Version>
+    <Version>1.1.8</Version>
     <PackageReadmeFile>Readme.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
 

--- a/Editorconfig/Kysect.Editorconfig.props
+++ b/Editorconfig/Kysect.Editorconfig.props
@@ -2,10 +2,9 @@
   <PropertyGroup>
     <WarningLevel>999</WarningLevel>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
-    <!-- CA rule configuration located in .editorconfig -->
-    <!-- <AnalysisLevel>latest</AnalysisLevel> -->
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <NoWarn Condition="$(IsTestProject) == 'true'">$(NoWarn);CA1707</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
@@ -17,7 +16,8 @@
     <EditorConfigFilesToCopy Include="$(MSBuildThisFileDirectory)..\content\Rules\.editorconfig" />
   </ItemGroup>
 
-  <Target Name="CopyEditorConfig" BeforeTargets="BeforeBuild">
+  <!-- *Undefined* is deafult value when dotnet try to build one project -->
+  <Target Name="CopyEditorConfig" BeforeTargets="BeforeBuild" Condition="$(SolutionDir) != '*Undefined*' and $(SolutionDir) != ''">
     <Message Text="Copying the .editorconfig file from '@(EditorConfigFilesToCopy)' to '$(SolutionDir)'"></Message>
     <Copy
       SourceFiles="@(EditorConfigFilesToCopy)"

--- a/Editorconfig/Readme.md
+++ b/Editorconfig/Readme.md
@@ -1,3 +1,5 @@
 # Kysect.Editorconfig
 
-Kysect.Editorconfig - это nuget библиотека для добавления .editorcofnig файла и .props файла. Это позволяет держать в одном месте эти файлы и подключать в разные проекты и при необходимости легко вносить изменения.
+Kysect.Editorconfig - это Nuget пакет, который предоставляет `.editorconfig` и `.props` файлы как подключаемую библиотеку. Это позволяет держать в одном месте эти файлы (в этом репозитории) и использовать во всех других репозиториях организации.
+
+Более подробно про то, как это устроено написано в блоге: https://publish.obsidian.md/how-to-kats/Personal+content/Blog/2024-01-21-Shared-output-directory-for-dotnet-projects.


### PR DESCRIPTION
- Fix case when dotnet build called for project
- Disable CA1701 (usage of '_') for test projects
- Update readme
- Increment package version